### PR TITLE
readme: clarify MotoROS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # moto
-A Python library for controlling Yaskawa MOTOMAN robots.
+A Python library for controlling Yaskawa MOTOMAN robots with the MotoROS option.
 
 ## Installation
 


### PR DESCRIPTION
As per subject.

This package doesn't appear to use `motoman_driver`, but requires MotoROS to be installed on the controller.
